### PR TITLE
Fix form filling livewire error

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -74,10 +74,6 @@ trait HandlesNavigationBuilder
         return [
             Action::make('item')
                 ->mountUsing(function (ComponentContainer $form) {
-                    if (! $this->mountedItem) {
-                        return;
-                    }
-
                     $form->fill($this->mountedItemData);
                 })
                 ->view('filament-navigation::hidden-action')


### PR DESCRIPTION
When clicking on the create-an-item button, we used to get an error in the front-end:

> Livewire Entangle Error: Livewire property ['mountedActionsData.0.type'] cannot be found on component: ['app.filament.resources.navigation-resource.pages.edit-navigation']

This was due to the fact that the form was conditionally filled, and that condition wasn't met.

Closes #101
